### PR TITLE
Adding Mood Visibility Toggle

### DIFF
--- a/code/app/src/main/java/com/example/moodster/EditMoodActivity.java
+++ b/code/app/src/main/java/com/example/moodster/EditMoodActivity.java
@@ -7,6 +7,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
+import android.widget.Switch;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -28,6 +29,7 @@ public class EditMoodActivity extends AppCompatActivity {
 
     private EditText reasonValue, triggerValue;
     private Spinner spinnerMood, spinnerSocialSituation;
+    private Switch switchVisibility;
     private MoodEvent eventToEdit;
     private String moodId;
     private String currentUsername;
@@ -57,8 +59,11 @@ public class EditMoodActivity extends AppCompatActivity {
         triggerValue = findViewById(R.id.textTriggerValue);
         spinnerMood = findViewById(R.id.textMoodEmoji);
         spinnerSocialSituation = findViewById(R.id.textSocialValue);
+        switchVisibility = findViewById(R.id.textVisibilityValue);
 
+        // limiting reason and trigger fields to 20 characters
         reasonValue.setFilters(new InputFilter[]{new InputFilter.LengthFilter(20)});
+        triggerValue.setFilters(new InputFilter[]{new InputFilter.LengthFilter(20)});
 
         ArrayAdapter<String> moodAdapter = new ArrayAdapter<>(
                 this, android.R.layout.simple_spinner_item, VALID_EMOTIONAL_STATES
@@ -79,6 +84,7 @@ public class EditMoodActivity extends AppCompatActivity {
             triggerValue.setText(eventToEdit.getTrigger());
             setSpinnerSelection(spinnerMood, eventToEdit.getEmotionalState());
             setSpinnerSelection(spinnerSocialSituation, eventToEdit.getSocialSituation());
+            switchVisibility.setChecked(eventToEdit.isPublic());
         }
 
         Button buttonCancel = findViewById(R.id.buttonCancel);
@@ -94,6 +100,7 @@ public class EditMoodActivity extends AppCompatActivity {
             eventToEdit.setTrigger(triggerValue.getText().toString());
             eventToEdit.setEmotionalState(spinnerMood.getSelectedItem().toString());
             eventToEdit.setSocialSituation(spinnerSocialSituation.getSelectedItem().toString());
+            eventToEdit.setPublic(switchVisibility.isChecked());
 
             moodEventViewModel.updateMoodEvent(eventToEdit, new MoodEventViewModel.OnUpdateListener() {
                 @Override

--- a/code/app/src/main/java/com/example/moodster/MainActivity.java
+++ b/code/app/src/main/java/com/example/moodster/MainActivity.java
@@ -21,7 +21,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.google.firebase.FirebaseApp;
-import com.google.firebase.Timestamp;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -129,7 +128,7 @@ public class MainActivity extends AppCompatActivity {
                     socialSituation,
                     explanation,
                     null, // image
-                    0, 0,
+                    0, 0, true,
                     new MoodEventViewModel.OnAddListener() {
                         @Override
                         public void onAddSuccess() {

--- a/code/app/src/main/java/com/example/moodster/MoodActivity.java
+++ b/code/app/src/main/java/com/example/moodster/MoodActivity.java
@@ -13,6 +13,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.Spinner;
+import android.widget.Switch;
 import android.widget.Toast;
 import androidx.activity.result.ActivityResult;
 import androidx.activity.result.ActivityResultCallback;
@@ -41,6 +42,7 @@ public class MoodActivity extends AppCompatActivity {
 
     private String selectedEmotionalState;
     private String currentUser;
+    private Switch publicToggle;
 
     public static final List<String> VALID_SOCIAL_SITUATION = Arrays.asList(
             "Alone, with one other person",
@@ -93,9 +95,11 @@ public class MoodActivity extends AppCompatActivity {
         btnCancel = findViewById(R.id.btn_cancel);
         btnViewMoodHistory = findViewById(R.id.btn_calendar);
         btnUploadImage = findViewById(R.id.btn_upload_image);
+        publicToggle = findViewById(R.id.publicToggle);
 
-        // Limit explanation
+        // Limit explanation and trigger fields to 20 characters
         editExplanation.setFilters(new InputFilter[]{new InputFilter.LengthFilter(20)});
+        editTrigger.setFilters(new InputFilter[]{new InputFilter.LengthFilter(20)});
 
         // Social spinner
         ArrayAdapter<String> socialAdapter = new ArrayAdapter<>(
@@ -113,6 +117,8 @@ public class MoodActivity extends AppCompatActivity {
             String socialSituation = spinnerSocialSituation.getSelectedItem().toString();
             String explanation = editExplanation.getText().toString().trim();
 
+            boolean isPublic = publicToggle.isChecked();
+
             fusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
 
             getCurrentLocation((lat, lon) -> {
@@ -128,6 +134,7 @@ public class MoodActivity extends AppCompatActivity {
                         selectedImageUri,
                         latitude,
                         longitude,
+                        isPublic,
                         new MoodEventViewModel.OnAddListener() {
                             @Override
                             public void onAddSuccess() {

--- a/code/app/src/main/java/com/example/moodster/MoodDetailsActivity.java
+++ b/code/app/src/main/java/com/example/moodster/MoodDetailsActivity.java
@@ -12,7 +12,7 @@ import androidx.appcompat.app.AppCompatActivity;
 public class MoodDetailsActivity extends AppCompatActivity {
 
     private TextView textMoodEmoji, textMoodDateTime, textReasonValue,
-            textTriggerValue, textSocialValue;
+            textTriggerValue, textSocialValue, textVisibilityValue;
     private ImageView imageMoodPhoto;
     private MoodEventViewModel moodEventViewModel;
     private String moodId;
@@ -46,6 +46,7 @@ public class MoodDetailsActivity extends AppCompatActivity {
         textReasonValue = findViewById(R.id.textReasonValue);
         textTriggerValue = findViewById(R.id.textTriggerValue);
         textSocialValue = findViewById(R.id.textSocialValue);
+        textVisibilityValue = findViewById(R.id.textVisibilityValue);
         imageMoodPhoto = findViewById(R.id.imageMoodPhoto);
         btnViewComments = findViewById(R.id.viewComments);
         btnDeleteMood = findViewById(R.id.buttonDelete);
@@ -57,6 +58,7 @@ public class MoodDetailsActivity extends AppCompatActivity {
         textReasonValue.setText(intent.getStringExtra("textReasonValue"));
         textTriggerValue.setText(intent.getStringExtra("textTriggerValue"));
         textSocialValue.setText(intent.getStringExtra("textSocialValue"));
+        textVisibilityValue.setText(intent.getStringExtra("textVisibilityValue"));
         imageMoodPhoto.setImageURI(intent.getParcelableExtra("imageMoodPhoto"));
 
         // ✅ Delete mood

--- a/code/app/src/main/java/com/example/moodster/MoodEvent.java
+++ b/code/app/src/main/java/com/example/moodster/MoodEvent.java
@@ -22,6 +22,7 @@ public class MoodEvent implements Serializable {
     // For Location
     private double latitude;
     private double longitude;
+    private boolean isPublic;
 
 
     // Predefined list of valid emotional states
@@ -30,7 +31,7 @@ public class MoodEvent implements Serializable {
     );
 
     // Constructor
-    public MoodEvent(String moodId, Timestamp createdAt, String emotionalState, String trigger, String socialSituation, String explanation, Uri image, double lat, double lon) {
+    public MoodEvent(String moodId, Timestamp createdAt, String emotionalState, String trigger, String socialSituation, String explanation, Uri image, double lat, double lon, boolean isPublic) {
         if (!VALID_EMOTIONAL_STATES.contains(emotionalState)) {
             throw new IllegalArgumentException("Invalid emotional state: " + emotionalState);
         }
@@ -46,6 +47,7 @@ public class MoodEvent implements Serializable {
         this.image = image;
         this.longitude = lon;
         this.latitude = lat;
+        this.isPublic = isPublic;
     }
 
     public String getEmoji() {
@@ -87,6 +89,9 @@ public class MoodEvent implements Serializable {
 
     public double getLatitude() { return latitude; }
     public double getLongitude() { return longitude; }
+    public boolean isPublic() {
+        return isPublic;
+    }
     public void setExplanation() { this.explanation = explanation; }
 
     // Setters for editable fields
@@ -115,6 +120,11 @@ public class MoodEvent implements Serializable {
         this.image = Image;
     }
 
+    public void setPublic(boolean isPublic) {
+        this.isPublic = isPublic;
+        this.lastEditAt = Timestamp.now();
+    }
+
     @Override
     public String toString() {
         return "MoodEvent{" +
@@ -127,6 +137,7 @@ public class MoodEvent implements Serializable {
                 ", explanation='" + explanation + '\'' +
                 ", lon= " + longitude + '\'' +
                 ", lat= " + latitude + '\'' +
+                ", isPublic=" + isPublic +
                 "}";
 
     }

--- a/code/app/src/main/java/com/example/moodster/MoodEventViewModel.java
+++ b/code/app/src/main/java/com/example/moodster/MoodEventViewModel.java
@@ -9,7 +9,6 @@ import android.util.Log;
 import androidx.lifecycle.ViewModel;
 
 import com.google.firebase.Timestamp;
-import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
@@ -92,7 +91,8 @@ public class MoodEventViewModel extends ViewModel {
                                                     doc.getString("explanation"),
                                                     null,
                                                     doc.contains("latitude") ? doc.getDouble("latitude") : 0.0,
-                                                    doc.contains("longitude") ? doc.getDouble("longitude") : 0.0
+                                                    doc.contains("longitude") ? doc.getDouble("longitude") : 0.0,
+                                                    doc.contains("isPublic") ? doc.getBoolean("isPublic") : true
                                             );
                                             fetched.add(moodEvent);
                                         } catch (Exception e) {
@@ -115,11 +115,11 @@ public class MoodEventViewModel extends ViewModel {
 
     // ----------------------- ADD -----------------------
     public void addMoodEvent(String emoState, String trigger, String social,
-                             String explanation, Uri image, double lat, double lon,
+                             String explanation, Uri image, double lat, double lon, boolean isPublic,
                              OnAddListener listener) {
 
         String id = UUID.randomUUID().toString();
-        MoodEvent newMood = new MoodEvent(id, Timestamp.now(), emoState, trigger, social, explanation, image, lat, lon);
+        MoodEvent newMood = new MoodEvent(id, Timestamp.now(), emoState, trigger, social, explanation, image, lat, lon, isPublic);
         this.onAddListener = listener;
         addMoodEvent(newMood);
         this.onAddListener = null;
@@ -143,6 +143,7 @@ public class MoodEventViewModel extends ViewModel {
         data.put("explanation", newMood.getExplanation());
         data.put("latitude", newMood.getLatitude());
         data.put("longitude", newMood.getLongitude());
+        data.put("isPublic", newMood.isPublic());
 
         db.collection("MoodEvents")
                 .document(id)
@@ -195,6 +196,7 @@ public class MoodEventViewModel extends ViewModel {
         data.put("explanation", updatedEvent.getExplanation());
         data.put("latitude", updatedEvent.getLatitude());
         data.put("longitude", updatedEvent.getLongitude());
+        data.put("isPublic", updatedEvent.isPublic());
 
         db.collection("MoodEvents").document(id).update(data)
                 .addOnSuccessListener(aVoid -> listener.onUpdateSuccess())

--- a/code/app/src/main/java/com/example/moodster/MoodListAdapter.java
+++ b/code/app/src/main/java/com/example/moodster/MoodListAdapter.java
@@ -66,6 +66,7 @@ public class MoodListAdapter extends BaseAdapter {
             intent.putExtra("textReasonValue", moodEvent.getExplanation());
             intent.putExtra("textTriggerValue", moodEvent.getTrigger());
             intent.putExtra("textSocialValue", moodEvent.getSocialSituation());
+            intent.putExtra("textVisibilityValue", moodEvent.isPublic() ? "Public" : "Private");
             intent.putExtra("imageMoodPhoto", moodEvent.getImage());
             intent.putExtra("moodId", moodEvent.getMoodId());
             intent.putExtra("username", currentUsername);

--- a/code/app/src/main/res/layout/activity_edit_mood.xml
+++ b/code/app/src/main/res/layout/activity_edit_mood.xml
@@ -235,6 +235,39 @@
             tools:ignore="HardcodedText" />
     </LinearLayout>
 
+    <!-- VISIBILITY ROW -->
+    <LinearLayout
+        android:id="@+id/layoutVisibility"
+        android:layout_width="361dp"
+        android:layout_height="47dp"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/bg_filter_bar"
+        android:orientation="horizontal"
+        android:padding="8dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/layoutSocialSituation">
+
+        <TextView
+            android:id="@+id/textVisibility"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Visibility :"
+            android:textColor="@android:color/black"
+            android:textSize="16sp"
+            tools:ignore="HardcodedText" />
+
+        <Switch
+            android:id="@+id/textVisibilityValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="8dp"
+            android:text="Post to Public: "
+            android:textColor="@android:color/black"
+            android:textSize="14sp"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
     <!-- IMAGE (E.g., "I Passed My Exams!") -->
     <LinearLayout
         android:id="@+id/layoutMoodImage"
@@ -246,7 +279,7 @@
         android:padding="8dp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/layoutSocialSituation">
+        app:layout_constraintTop_toBottomOf="@+id/layoutVisibility">
 
         <ImageView
             android:id="@+id/imageMoodPhoto"

--- a/code/app/src/main/res/layout/activity_press_view_details_mood_history.xml
+++ b/code/app/src/main/res/layout/activity_press_view_details_mood_history.xml
@@ -235,6 +235,39 @@
             tools:ignore="HardcodedText" />
     </LinearLayout>
 
+    <!-- VISIBILITY ROW -->
+    <LinearLayout
+        android:id="@+id/layoutVisibility"
+        android:layout_width="361dp"
+        android:layout_height="47dp"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/bg_filter_bar"
+        android:orientation="horizontal"
+        android:padding="8dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/layoutSocialSituation">
+
+        <TextView
+            android:id="@+id/textVisibility"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Visibility :"
+            android:textColor="@android:color/black"
+            android:textSize="16sp"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:id="@+id/textVisibilityValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="8dp"
+            android:text="-"
+            android:textColor="@android:color/black"
+            android:textSize="14sp"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
     <!-- IMAGE (E.g., "I Passed My Exams!") -->
     <LinearLayout
         android:id="@+id/layoutMoodImage"
@@ -246,7 +279,7 @@
         android:padding="8dp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/layoutSocialSituation">
+        app:layout_constraintTop_toBottomOf="@+id/layoutVisibility">
 
         <ImageView
             android:id="@+id/imageMoodPhoto"

--- a/code/app/src/main/res/layout/angry_mood.xml
+++ b/code/app/src/main/res/layout/angry_mood.xml
@@ -72,14 +72,15 @@
     <!-- Bottom Navigation Bar -->
 
 
-    <TextView
-        android:id="@+id/date_time"
-        android:layout_width="match_parent"
+    <Switch
+        android:id="@+id/publicToggle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/angry"
         android:layout_marginTop="-2dp"
+        android:layout_centerHorizontal="true"
         android:gravity="center"
-        android:text="Select Date and Time"
+        android:text="Post to Public"
         android:textColor="@android:color/black"
         android:textSize="16sp" />
 

--- a/code/app/src/main/res/layout/confusion_mood.xml
+++ b/code/app/src/main/res/layout/confusion_mood.xml
@@ -46,17 +46,17 @@
         android:layout_centerHorizontal="true"
         android:layout_marginTop="5dp" />
 
-    <!-- Date and Time Text -->
-    <TextView
-        android:id="@+id/date_time"
-        android:layout_width="match_parent"
+    <Switch
+        android:id="@+id/publicToggle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/confusion"
         android:layout_marginTop="-2dp"
+        android:layout_centerHorizontal="true"
         android:gravity="center"
-        android:text="Select Date and Time"
-        android:textSize="16sp"
-        android:textColor="@android:color/black" />
+        android:text="Post to Public"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 
     <!-- Reason Input Field with Gradient Background -->
     <LinearLayout

--- a/code/app/src/main/res/layout/disgust_mood.xml
+++ b/code/app/src/main/res/layout/disgust_mood.xml
@@ -47,16 +47,17 @@
         android:layout_marginTop="5dp" />
 
     <!-- Date and Time Text -->
-    <TextView
-        android:id="@+id/date_time"
-        android:layout_width="match_parent"
+    <Switch
+        android:id="@+id/publicToggle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/disgust"
         android:layout_marginTop="-2dp"
+        android:layout_centerHorizontal="true"
         android:gravity="center"
-        android:text="Select Date and Time"
-        android:textSize="16sp"
-        android:textColor="@android:color/black" />
+        android:text="Post to Public"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 
     <!-- Reason Input Field with Gradient Background -->
     <LinearLayout

--- a/code/app/src/main/res/layout/fear_mood.xml
+++ b/code/app/src/main/res/layout/fear_mood.xml
@@ -46,17 +46,17 @@
         android:layout_centerHorizontal="true"
         android:layout_marginTop="5dp" />
 
-    <!-- Date and Time Text -->
-    <TextView
-        android:id="@+id/date_time"
-        android:layout_width="match_parent"
+    <Switch
+        android:id="@+id/publicToggle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/fear"
         android:layout_marginTop="-2dp"
+        android:layout_centerHorizontal="true"
         android:gravity="center"
-        android:text="Select Date and Time"
-        android:textSize="16sp"
-        android:textColor="@android:color/black" />
+        android:text="Post to Public"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 
     <!-- Reason Input Field with Gradient Background -->
     <LinearLayout

--- a/code/app/src/main/res/layout/happy_mood.xml
+++ b/code/app/src/main/res/layout/happy_mood.xml
@@ -47,16 +47,17 @@
         android:layout_marginTop="5dp" />
 
     <!-- Date and Time Text -->
-    <TextView
-        android:id="@+id/date_time"
-        android:layout_width="match_parent"
+    <Switch
+        android:id="@+id/publicToggle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/happy"
         android:layout_marginTop="-2dp"
+        android:layout_centerHorizontal="true"
         android:gravity="center"
-        android:text="Select Date and Time"
-        android:textSize="16sp"
-        android:textColor="@android:color/black" />
+        android:text="Post to Public"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 
     <!-- Reason Input Field with Gradient Background -->
     <LinearLayout

--- a/code/app/src/main/res/layout/sad_mood.xml
+++ b/code/app/src/main/res/layout/sad_mood.xml
@@ -46,17 +46,17 @@
         android:layout_centerHorizontal="true"
         android:layout_marginTop="5dp" />
 
-    <!-- Date and Time Text -->
-    <TextView
-        android:id="@+id/date_time"
-        android:layout_width="match_parent"
+    <Switch
+        android:id="@+id/publicToggle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/sad"
         android:layout_marginTop="-2dp"
+        android:layout_centerHorizontal="true"
         android:gravity="center"
-        android:text="Select Date and Time"
-        android:textSize="16sp"
-        android:textColor="@android:color/black" />
+        android:text="Post to Public"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 
     <!-- Reason Input Field with Gradient Background -->
     <LinearLayout

--- a/code/app/src/main/res/layout/shame_mood.xml
+++ b/code/app/src/main/res/layout/shame_mood.xml
@@ -47,16 +47,17 @@
         android:layout_marginTop="5dp" />
 
     <!-- Date and Time Text -->
-    <TextView
-        android:id="@+id/date_time"
-        android:layout_width="match_parent"
+    <Switch
+        android:id="@+id/publicToggle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/shame"
         android:layout_marginTop="-2dp"
+        android:layout_centerHorizontal="true"
         android:gravity="center"
-        android:text="Select Date and Time"
-        android:textSize="16sp"
-        android:textColor="@android:color/black" />
+        android:text="Post to Public"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 
     <!-- Reason Input Field with Gradient Background -->
     <LinearLayout

--- a/code/app/src/main/res/layout/surprise_mood.xml
+++ b/code/app/src/main/res/layout/surprise_mood.xml
@@ -47,16 +47,17 @@
         android:layout_marginTop="5dp" />
 
     <!-- Date and Time Text -->
-    <TextView
-        android:id="@+id/date_time"
-        android:layout_width="match_parent"
+    <Switch
+        android:id="@+id/publicToggle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/surprise"
         android:layout_marginTop="-2dp"
+        android:layout_centerHorizontal="true"
         android:gravity="center"
-        android:text="Select Date and Time"
-        android:textSize="16sp"
-        android:textColor="@android:color/black" />
+        android:text="Post to Public"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 
     <!-- Reason Input Field with Gradient Background -->
     <LinearLayout


### PR DESCRIPTION
Closes #117 (US 01.07.01). Adds mood visibility toggle to all 8 mood themed add mood screen xmls. Also adds the ability to view the visibility status in MoodDetailsActivity, as well as the ability to edit the visibility status in EditMoodActivity. 

This implementation modifies 6 java classes (excluding MainActivity.java because it will be removed from the codebase shortly):
- EditMoodActivity.java : Bound the new visibility Switch (textVisibilityValue) from the activity_edit_mood.xml, loaded its state based on the existing event's isPublic property, and updated the event accordingly when saving.
- MoodActivity.java; Modified the activity to bind a toggle switch (publicToggle) from the mood themed xml files, capture its state, and pass that boolean value to the view model when creating a new mood event.
- MoodDetailsActivity.java; Bound the new visibility TextView (textVisibilityValue) and displayed the mood visibility status (Public or Private) in the details view.
- MoodEvent.java; Added a new boolean field (isPublic) along with its getter and setter
- MoodEventViewModel.java; Updated methods for adding, updating, and fetching mood events to include the new isPublic flag when saving to or reading from Firebase.
- MoodListAdapter.java; Updated the adapter to pass the mood event’s visibility intent when launching the details activity

There are also 10 layout xml's that were modified as part of this PR, 8 of which were the mood themed add mood screens to add the Switch toggle:
- happy_mood.xml
- angry_mood.xml
- sad_mood.xml
- confusion_mood.xml
- disgust_mood.xml
- shame_mood.xml
- surprise_mood.xml
- fear_mood.xml

as well as the xml's for viewing mood details and mood editing to add the visibility status and enable editing the toggle status for mood visibility:
- activity_press_view_details_mood_history.xml
- activity_edit_mood.xml